### PR TITLE
Sett clientid pr consumer for å unngå warning

### DIFF
--- a/src/main/java/no/nav/tag/finnkandidatapi/kafka/oppfølgingAvsluttet/OppfølgingAvsluttetConsumer.java
+++ b/src/main/java/no/nav/tag/finnkandidatapi/kafka/oppfølgingAvsluttet/OppfølgingAvsluttetConsumer.java
@@ -31,7 +31,11 @@ public class OppfølgingAvsluttetConsumer {
         meterRegistry.counter(AVSLUTTET_OPPFØLGING_FEILET);
     }
 
-    @KafkaListener(topics = "#{oppfolgingAvsluttetConfig.getTopic()}", groupId = "finn-kandidat-oppfolging-avsluttet")
+    @KafkaListener(
+            topics = "#{oppfolgingAvsluttetConfig.getTopic()}",
+            groupId = "finn-kandidat-oppfolging-avsluttet",
+            clientIdPrefix = "oppfolging-avsluttet"
+    )
     public void konsumerMelding(ConsumerRecord<String, String> melding) {
         log.info(
                 "Konsumerer avsluttet oppfølging melding for id {}, offset: {}, partition: {}",

--- a/src/main/java/no/nav/tag/finnkandidatapi/kafka/oppfølgingEndret/OppfølgingEndretConsumer.java
+++ b/src/main/java/no/nav/tag/finnkandidatapi/kafka/oppfølgingEndret/OppfølgingEndretConsumer.java
@@ -32,7 +32,11 @@ public class OppfølgingEndretConsumer {
         meterRegistry.counter(ENDRET_OPPFØLGING_FEILET);
     }
 
-    @KafkaListener(topics = "#{oppfolgingEndretConfig.getTopic()}", groupId = "finn-kandidat-oppfolging-endret")
+    @KafkaListener(
+            topics = "#{oppfolgingEndretConfig.getTopic()}",
+            groupId = "finn-kandidat-oppfolging-endret",
+            clientIdPrefix = "oppfolging-endret"
+    )
     public void konsumerMelding(ConsumerRecord<String, String> melding) {
         log.info(
                 "Konsumerer oppfølging endret melding for id {}, offset: {}, partition: {}",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,8 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       auto-offset-reset: earliest
     producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
       retries: 25
 
 kandidat-endret.topic: aapen-tag-kandidatEndret-v1-default
@@ -65,9 +67,6 @@ spring:
       ssl.truststore:
         location: ${javax.net.ssl.trustStore}
         password: ${javax.net.ssl.trustStorePassword}
-      producer:
-        key-serializer: org.apache.kafka.common.serialization.StringSerializer
-        value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 oppfolging-avsluttet.topic: aapen-fo-endringPaaAvsluttOppfolging-v1-q0
 oppfolging-endret.topic: aapen-fo-endringPaaOppfoelgingsBruker-v1-q0
@@ -109,9 +108,6 @@ spring:
       ssl.truststore:
         location: ${javax.net.ssl.trustStore}
         password: ${javax.net.ssl.trustStorePassword}
-      producer:
-        key-serializer: org.apache.kafka.common.serialization.StringSerializer
-        value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 oppfolging-avsluttet.topic: aapen-fo-endringPaaAvsluttOppfolging-v1-p
 oppfolging-endret.topic: aapen-fo-endringPaaOppfoelgingsBruker-v1-p


### PR DESCRIPTION
Etter vi innførte flere enn én consumer i appen fikk vi denne exceptionen ved oppstart:
`javax.management.InstanceAlreadyExistsException: kafka.consumer:type=app-info,id=finn-kandidat-api-0` pga. vi har flere kafka consumere med samme client-id.

Unngår dette ved å sette en client-id-prefix på hver consumer.
https://github.com/logstash-plugins/logstash-input-kafka/issues/251