### PR TITLE
Feature/utvide kandidat

### DIFF
--- a/src/main/java/no/nav/finnkandidatapi/kafka/harTilretteleggingsbehov/HarTilretteleggingsbehovProducer.java
+++ b/src/main/java/no/nav/finnkandidatapi/kafka/harTilretteleggingsbehov/HarTilretteleggingsbehovProducer.java
@@ -48,18 +48,19 @@ public class HarTilretteleggingsbehovProducer {
 
     @EventListener
     public void kandidatOpprettet(KandidatOpprettet event) {
-        Kandidat kandidat = event.getKandidat();
-        List<String> kategorier = kandidat.kategorier();
-        HarTilretteleggingsbehov melding = new HarTilretteleggingsbehov(kandidat.getAktørId(), true, kategorier);
-        sendKafkamelding(melding);
+        kandidatEndretEllerOpprettet(event.getKandidat());
     }
 
     @EventListener
     public void kandidatEndret(KandidatEndret event) {
-        Kandidat kandidat = event.getKandidat();
+        kandidatEndretEllerOpprettet(event.getKandidat());
+    }
+
+    private void kandidatEndretEllerOpprettet(Kandidat kandidat) {
         List<String> kategorier = kandidat.kategorier();
+        List<String> kategorierOgPermittert = kandidat.kategorierOgPermittert();
         boolean harBehov = !kategorier.isEmpty();
-        HarTilretteleggingsbehov melding = new HarTilretteleggingsbehov(kandidat.getAktørId(), harBehov, kategorier);
+        HarTilretteleggingsbehov melding = new HarTilretteleggingsbehov(kandidat.getAktørId(), harBehov, kategorierOgPermittert);
         sendKafkamelding(melding);
     }
 

--- a/src/main/java/no/nav/finnkandidatapi/kandidat/Kandidat.java
+++ b/src/main/java/no/nav/finnkandidatapi/kandidat/Kandidat.java
@@ -41,7 +41,7 @@ public class Kandidat {
                 .arbeidshverdagen(kandidat.getArbeidshverdagen())
                 .utfordringerMedNorsk(kandidat.getUtfordringerMedNorsk())
                 .navKontor(navKontor)
-                .permittert(null)
+                .permittert(Collections.emptySet())
                 .build();
     }
 
@@ -72,7 +72,6 @@ public class Kandidat {
         Set<Fysisk> fysisk = this.getFysisk();
         Set<Arbeidshverdagen> arbeidshverdagen = this.getArbeidshverdagen();
         Set<UtfordringerMedNorsk> utfordringerMedNorsk = this.getUtfordringerMedNorsk();
-        Set<Permittert> permitteringer = this.getPermittert();
 
         if (arbeidstid != null && !arbeidstid.isEmpty()) {
             kategorier.add(Arbeidstid.behovskategori);
@@ -90,10 +89,16 @@ public class Kandidat {
             kategorier.add(UtfordringerMedNorsk.behovskategori);
         }
 
-        if (permitteringer != null && !permitteringer.isEmpty()) {
-            kategorier.add(Permittert.permittertkategori);
-        }
-
         return Collections.unmodifiableList(kategorier);
+    }
+
+    public List<String> kategorierOgPermittert() {
+        List<String> kategorierOgPermittert = new ArrayList<>(kategorier());
+        Set<Permittert> permitteringer = this.getPermittert();
+
+        if( permitteringer != null && !permitteringer.isEmpty()) {
+            kategorierOgPermittert.add(Permittert.permittertkategori);
+        }
+        return kategorierOgPermittert;
     }
 }

--- a/src/main/java/no/nav/finnkandidatapi/kandidat/Kandidat.java
+++ b/src/main/java/no/nav/finnkandidatapi/kandidat/Kandidat.java
@@ -23,6 +23,7 @@ public class Kandidat {
     private Set<Arbeidshverdagen> arbeidshverdagen;
     private Set<UtfordringerMedNorsk> utfordringerMedNorsk;
     private String navKontor;
+    private Set<Permittert> permittert;
 
     public static Kandidat opprettKandidat(
             KandidatDto kandidat,
@@ -40,6 +41,7 @@ public class Kandidat {
                 .arbeidshverdagen(kandidat.getArbeidshverdagen())
                 .utfordringerMedNorsk(kandidat.getUtfordringerMedNorsk())
                 .navKontor(navKontor)
+                .permittert(null)
                 .build();
     }
 
@@ -60,6 +62,7 @@ public class Kandidat {
                 .arbeidshverdagen(kandidatDto.getArbeidshverdagen())
                 .utfordringerMedNorsk(kandidatDto.getUtfordringerMedNorsk())
                 .navKontor(kandidat.getNavKontor())
+                .permittert(kandidat.getPermittert())
                 .build();
     }
 
@@ -69,6 +72,7 @@ public class Kandidat {
         Set<Fysisk> fysisk = this.getFysisk();
         Set<Arbeidshverdagen> arbeidshverdagen = this.getArbeidshverdagen();
         Set<UtfordringerMedNorsk> utfordringerMedNorsk = this.getUtfordringerMedNorsk();
+        Set<Permittert> permitteringer = this.getPermittert();
 
         if (arbeidstid != null && !arbeidstid.isEmpty()) {
             kategorier.add(Arbeidstid.behovskategori);
@@ -84,6 +88,10 @@ public class Kandidat {
 
         if (utfordringerMedNorsk != null && !utfordringerMedNorsk.isEmpty()) {
             kategorier.add(UtfordringerMedNorsk.behovskategori);
+        }
+
+        if (permitteringer != null && !permitteringer.isEmpty()) {
+            kategorier.add(Permittert.permittertkategori);
         }
 
         return Collections.unmodifiableList(kategorier);

--- a/src/main/java/no/nav/finnkandidatapi/kandidat/KandidatMapper.java
+++ b/src/main/java/no/nav/finnkandidatapi/kandidat/KandidatMapper.java
@@ -39,6 +39,7 @@ public class KandidatMapper implements RowMapper<Kandidat> {
                 .arbeidshverdagen(stringTilEnumSet(rs.getString(ARBEIDSHVERDAGEN_BEHOV), Arbeidshverdagen.class))
                 .utfordringerMedNorsk(stringTilEnumSet(rs.getString(UTFORDRINGERMEDNORSK_BEHOV), UtfordringerMedNorsk.class))
                 .navKontor(rs.getString(NAV_KONTOR))
+                .permittert(stringTilEnumSet(rs.getString(PERMITTERT), Permittert.class))
                 .build();
     }
 

--- a/src/main/java/no/nav/finnkandidatapi/kandidat/KandidatRepository.java
+++ b/src/main/java/no/nav/finnkandidatapi/kandidat/KandidatRepository.java
@@ -35,6 +35,7 @@ public class KandidatRepository {
     static final String SLETTET = "slettet";
     static final String OPPRETTET = "opprettet";
     static final String NAV_KONTOR = "nav_kontor";
+    static final String PERMITTERT = "permittert";
 
     private JdbcTemplate jdbcTemplate;
     private SimpleJdbcInsert jdbcInsert;
@@ -142,6 +143,7 @@ public class KandidatRepository {
         parameters.put(NAV_KONTOR, kandidat.getNavKontor());
         parameters.put(SLETTET, false);
         parameters.put(OPPRETTET, LocalDateTime.now());
+        parameters.put(PERMITTERT, enumSetTilString(kandidat.getPermittert()));
 
         return parameters;
     }

--- a/src/main/java/no/nav/finnkandidatapi/kandidat/KandidatService.java
+++ b/src/main/java/no/nav/finnkandidatapi/kandidat/KandidatService.java
@@ -14,7 +14,6 @@ import no.nav.finnkandidatapi.veilarbarena.VeilarbArenaClient;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -127,16 +126,10 @@ public class KandidatService {
         return aktørRegisterClient.tilFnr(aktørId);
     }
 
-    Optional<Integer> slettKandidat(String aktørId, Veileder innloggetVeileder) {
-        LocalDateTime slettetTidspunkt = dateProvider.now();
-        Optional<Integer> optionalId = kandidatRepository.slettKandidatSomVeileder(aktørId, innloggetVeileder, slettetTidspunkt);
-
-        optionalId.ifPresent(id -> {
-            KandidatSlettet event = new KandidatSlettet(id, aktørId, Brukertype.VEILEDER, slettetTidspunkt);
-            eventPublisher.publishEvent(event);
-        });
-
-        return optionalId;
+    Optional<Integer> slettKandidatsTilretteleggingsbehov(String aktørId, Veileder innloggetVeileder) {
+        KandidatDto kandidatUtenTilretteleggingebehov = KandidatDto.builder().aktørId(aktørId).build();
+        Optional<Kandidat> optionalEndretKandidat = endreKandidat(kandidatUtenTilretteleggingebehov, innloggetVeileder);
+        return optionalEndretKandidat.map(kandidat -> kandidat.getId());
     }
 
     public boolean kandidatEksisterer(String aktørId) {

--- a/src/main/java/no/nav/finnkandidatapi/kandidat/Permittert.java
+++ b/src/main/java/no/nav/finnkandidatapi/kandidat/Permittert.java
@@ -1,0 +1,7 @@
+package no.nav.finnkandidatapi.kandidat;
+
+public enum Permittert {
+    SELV_REG_FRA_VEIL_ARB;
+
+    public final static String permittertkategori = "permittert";
+}

--- a/src/main/resources/db/migration/V9__legg-til-permittert.sql
+++ b/src/main/resources/db/migration/V9__legg-til-permittert.sql
@@ -1,0 +1,1 @@
+ALTER TABLE kandidat ADD COLUMN permittert VARCHAR(1000);

--- a/src/test/java/no/nav/finnkandidatapi/TestData.java
+++ b/src/test/java/no/nav/finnkandidatapi/TestData.java
@@ -37,6 +37,7 @@ public class TestData {
                 .arbeidshverdagen(Set.of(MENTOR, TILRETTELAGTE_ARBEIDSOPPGAVER))
                 .utfordringerMedNorsk(Set.of(SNAKKE_NORSK, SKRIVE_NORSK, LESE_NORSK))
                 .navKontor(etNavKontor())
+                .permittert(Collections.emptySet())
                 .build();
     }
 
@@ -83,7 +84,8 @@ public class TestData {
                 .arbeidstid(Set.of(KAN_IKKE_JOBBE))
                 .fysisk(Set.of(ARBEIDSSTILLING, ERGONOMI))
                 .arbeidshverdagen(Set.of(MENTOR, TILRETTELAGTE_ARBEIDSOPPGAVER))
-                .utfordringerMedNorsk(Set.of(SNAKKE_NORSK, SKRIVE_NORSK, LESE_NORSK));
+                .utfordringerMedNorsk(Set.of(SNAKKE_NORSK, SKRIVE_NORSK, LESE_NORSK))
+                .permittert(Collections.emptySet());
     }
 
     public static Veileder enVeileder() {
@@ -108,6 +110,7 @@ public class TestData {
                 .fysisk(Collections.emptySet())
                 .arbeidshverdagen(Collections.emptySet())
                 .utfordringerMedNorsk(Collections.emptySet())
+                .permittert(Collections.emptySet())
                 .build();
     }
 

--- a/src/test/java/no/nav/finnkandidatapi/TestData.java
+++ b/src/test/java/no/nav/finnkandidatapi/TestData.java
@@ -41,6 +41,21 @@ public class TestData {
                 .build();
     }
 
+    public static Kandidat enKandidatUtenTilretteleggingsbehov() {
+        return Kandidat.builder()
+                .sistEndretAvVeileder(now())
+                .sistEndretAv(enNavIdent())
+                .fnr(etFnr())
+                .aktørId("1000000000001")
+                .arbeidstid(Collections.emptySet())
+                .fysisk(Collections.emptySet())
+                .arbeidshverdagen(Collections.emptySet())
+                .utfordringerMedNorsk(Collections.emptySet())
+                .navKontor(etNavKontor())
+                .permittert(Collections.emptySet())
+                .build();
+    }
+
     public static KandidatDto enKandidatDto(Kandidat kandidat) {
         return KandidatDto.builder()
                 .fnr(kandidat.getFnr())

--- a/src/test/java/no/nav/finnkandidatapi/kandidat/KandidatControllerTest.java
+++ b/src/test/java/no/nav/finnkandidatapi/kandidat/KandidatControllerTest.java
@@ -270,6 +270,14 @@ public class KandidatControllerTest {
         controller.hentKandidat(aktørId);
     }
 
+    @Test(expected = NotFoundException.class)
+    public void hentKandidat__skal_kaste_NotFoundException_hvis_kandidat_fins_men_ikke_har_tilretteleggingsbehov() {
+        værInnloggetSom(enVeileder());
+        String aktørId = enKandidatUtenTilretteleggingsbehov().getAktørId();
+        when(service.hentNyesteKandidat(aktørId)).thenReturn(Optional.of(enKandidatUtenTilretteleggingsbehov()));
+        controller.hentKandidat(aktørId);
+    }
+
 
     @Test
     public void hentKandidat__med_fnr_skal_returnere_ok_med_kandidat() {

--- a/src/test/java/no/nav/finnkandidatapi/kandidat/KandidatControllerTest.java
+++ b/src/test/java/no/nav/finnkandidatapi/kandidat/KandidatControllerTest.java
@@ -129,13 +129,31 @@ public class KandidatControllerTest {
     @Test
     public void opprettKandidat__skal_returnere_conflict_hvis_kandidat_eksisterer() {
         KandidatDto kandidatDto = enKandidatDto();
+        Kandidat kandidat = enKandidat();
         Veileder veileder = enVeileder();
         værInnloggetSom(veileder);
 
         when(service.kandidatEksisterer(kandidatDto.getAktørId())).thenReturn(true);
+        when(service.hentNyesteKandidat(kandidatDto.getAktørId())).thenReturn(Optional.of(kandidat));
 
         ResponseEntity<Kandidat> respons = controller.opprettKandidat(kandidatDto);
         assertThat(respons.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    public void opprettKandidat__skal_endre_kandidat_hvis_kandidat_uten_tilretteleggingsbehov_eksisterer() {
+        KandidatDto kandidatDto = enKandidatDto();
+        Kandidat tomKandidat = enKandidatMedNullOgTommeSet();
+        Kandidat fullKandidat = enKandidat();
+        Veileder veileder = enVeileder();
+        værInnloggetSom(veileder);
+
+        when(service.kandidatEksisterer(kandidatDto.getAktørId())).thenReturn(true);
+        when(service.hentNyesteKandidat(kandidatDto.getAktørId())).thenReturn(Optional.of(tomKandidat));
+        when(service.endreKandidat(kandidatDto, veileder)).thenReturn(Optional.of(fullKandidat));
+
+        ResponseEntity<Kandidat> respons = controller.opprettKandidat(kandidatDto);
+        assertThat(respons.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     }
 
     @Test
@@ -359,7 +377,7 @@ public class KandidatControllerTest {
         værInnloggetSom(veileder);
         Kandidat kandidat = enKandidat();
 
-        when(service.slettKandidat(kandidat.getAktørId(), veileder)).thenReturn(Optional.of(1));
+        when(service.slettKandidatsTilretteleggingsbehov(kandidat.getAktørId(), veileder)).thenReturn(Optional.of(1));
         ResponseEntity respons = controller.slettKandidat(kandidat.getAktørId());
 
         assertThat(respons.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -373,10 +391,10 @@ public class KandidatControllerTest {
         String aktørId = enAktørId();
 
         when(service.hentAktørId(fnr)).thenReturn(aktørId);
-        when(service.slettKandidat(aktørId, veileder)).thenReturn(Optional.of(1));
+        when(service.slettKandidatsTilretteleggingsbehov(aktørId, veileder)).thenReturn(Optional.of(1));
 
         ResponseEntity respons = controller.slettKandidat(fnr);
-        verify(service).slettKandidat(aktørId, veileder);
+        verify(service).slettKandidatsTilretteleggingsbehov(aktørId, veileder);
 
         assertThat(respons.getStatusCode()).isEqualTo(HttpStatus.OK);
     }


### PR DESCRIPTION
Utvider kandidat med permittert-felt.

Målet med denne PRen er at finn-kandidat-api applikasjonen skal fungere likt mot frontend som før. Vi har ennå ikke dratt inn den nye topicen til veilarb, denne PRen klargjør bare grunnen for å dra inn den. 

Hvis en veileder sletter en kandidat, så slettes bare kandidatens tilretteleggingsbehov. Kandidaten blir "tom". Det medfører at det opprettes en Endret-event og ikke en Slettet-event, så vi publiserer en annen melding til PAM.

Hvis en veileder henter opp en "tom" kandidat, så behandler systemet det likt som om kandidaten ikke finnes. Det innebærer at det fremdeles returneres en 404.

Hvis en veileder oppretter en kandidat, og det allerede finnes en kandidat med den aktørIden, og den kandidaten er "tom", så blir det en endring av den eksisterende kandidaten, så den lagres med oppdaterte tilretteleggingsbehov. Det blir sendt en endret-melding til PAM, ikke en opprett-melding. Og Controlleren returnerer CREATED som før, så APIet mot GUI er likt.

APIet mot GUI skal alltid være likt som før, men meldingene som publiseres endres litt. Det er vel som det må være.

Jeg har endret en del tester, men ikke lagt til så ekstremt mange nye. Jeg kan gjerne lage litt flere, hvis det er ønskelig? 