### PR TITLE
Høyere toleranse for HTTP 4xx responser før alert utløses

### DIFF
--- a/alerts/alerts-dev.yaml
+++ b/alerts/alerts-dev.yaml
@@ -49,6 +49,6 @@ spec:
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"
     - alert: (finn-kandidat-api) Økning HTTP klientfeil (4xx responser andre enn 401)
       severity: warning
-      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^4\\d[0,2-9]", backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])))) > 40
+      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^4\\d[0,2-9]", backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])))) > 60
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"

--- a/alerts/alerts-prod.yaml
+++ b/alerts/alerts-prod.yaml
@@ -50,6 +50,6 @@ spec:
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"
     - alert: Økning HTTP klientfeil (4xx responser andre enn 401)
       severity: warning
-      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^4\\d[0,2-9]", backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])))) > 40
+      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^4\\d[0,2-9]", backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"arbeidsgiver.nais.*/finn-kandidat-api/*"}[3m])))) > 60
       for: 3m
       action: "Sjekk loggene for å se hvorfor {{ $labels.backend }} returnerer HTTP feilresponser"


### PR DESCRIPTION
Har allerede deployet endringen med `kubectl apply ..." i dev og prod.